### PR TITLE
Make hydroform work with the latest kind provider

### DIFF
--- a/provision/examples/kind/README.md
+++ b/provision/examples/kind/README.md
@@ -9,7 +9,7 @@ To provision a Kind cluster you need Docker with memory settings configured to s
 
 ### Run the example
 
-1. To provision a new cluster on Azure, go to the `provision` directory and run:
+1. To provision a new kind cluster, go to the `provision` directory and run:
 
     ```bash
     go run ./examples/kind/main.go -p {project-name} -n {dockerhub/image:tag} --persist

--- a/provision/internal/operator/terraform/operator.go
+++ b/provision/internal/operator/terraform/operator.go
@@ -50,6 +50,10 @@ func (t *Terraform) Create(p types.ProviderType, cfg map[string]interface{}) (*t
 		if err := initGardenerProvider(); err != nil {
 			return nil, errors.Wrap(err, "could not initialize the gardener provider")
 		}
+	} else if p == types.Kind {
+		if err := initKindProvider(); err != nil {
+			return nil, errors.Wrap(err, "could not initialize the kind provider")
+		}
 	}
 	if err := tfInit(t.ops, p, cfg, clusterDir); err != nil {
 		return nil, err

--- a/provision/internal/operator/terraform/provider.go
+++ b/provision/internal/operator/terraform/provider.go
@@ -15,14 +15,26 @@ import (
 // TODO remove this file when the gardener provider is on the official terraform registry
 
 const (
-	providerURL     = "https://github.com/kyma-incubator/terraform-provider-gardener/releases/download/%s/terraform-provider-gardener-%s-%s"
-	providerName    = "terraform-provider-gardener"
-	providerVersion = "v0.0.9"
+	gardenerProviderURL     = "https://github.com/kyma-incubator/terraform-provider-gardener/releases/download/%s/terraform-provider-gardener-%s-%s"
+	gardenerProviderName    = "terraform-provider-gardener"
+	gardenerProviderVersion = "v0.0.9"
+
+	kindProviderURL     = "https://github.com/kyma-incubator/terraform-provider-kind/releases/download/%s/terraform-provider-kind-%s-%s"
+	kindProviderName    = "terraform-provider-kind"
+	kindProviderVersion = "v0.0.1"
 )
 
 // initGardenerProvider will check if the gardener provider is available and download it if not.
 
 func initGardenerProvider() error {
+	return initProvider(gardenerProviderName, gardenerProviderVersion, gardenerProviderURL)
+}
+func initKindProvider() error {
+	return nil
+	// return initProvider(kindProviderName, kindProviderVersion, kindProviderURL)
+}
+
+func initProvider(providerName, providerVersion, providerURL string) error {
 	pluginDirs, err := globalPluginDirs()
 	if err != nil {
 		return err

--- a/provision/internal/operator/terraform/provider.go
+++ b/provision/internal/operator/terraform/provider.go
@@ -30,8 +30,7 @@ func initGardenerProvider() error {
 	return initProvider(gardenerProviderName, gardenerProviderVersion, gardenerProviderURL)
 }
 func initKindProvider() error {
-	return nil
-	// return initProvider(kindProviderName, kindProviderVersion, kindProviderURL)
+	return initProvider(kindProviderName, kindProviderVersion, kindProviderURL)
 }
 
 func initProvider(providerName, providerVersion, providerURL string) error {


### PR DESCRIPTION
**Description**

This PR enables cluster creation via hydroform, correctly reading the kubeconfig from the created kind cluster. *DO NOT MERGE* unless there is a release for the kind provider created or it won't work.
After this is merged work that I started on the CLI can continue so that this will work on provisioning kind clusters with the CLI as well.

Changes proposed in this pull request:
- Correctly read kubeconfig from created cluster
- Write back kubeconfig for use in CLI

**Related issue(s)**
Using all the changes from latest kind provider: https://github.com/kyma-incubator/terraform-provider-kind/pull/12
