### PR TITLE
Add InstallLegacyCRDs interceptor

### DIFF
--- a/parallel-install/go.sum
+++ b/parallel-install/go.sum
@@ -1,6 +1,7 @@
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
@@ -9,6 +10,7 @@ cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go v0.52.0/go.mod h1:pXajvRH/6o3+F9jDHZWQ5PbGhn+o8w9qiu/CffaVdO4=
 cloud.google.com/go v0.53.0/go.mod h1:fp/UouUEsRkN6ryDKNW/Upv/JBKnv6WDthjR6+vze6M=
+cloud.google.com/go v0.54.0 h1:3ithwDMr7/3vpAMXiH+ZQnYbuIsh+OPhUPMFC9enmn0=
 cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bPc=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=

--- a/parallel-install/pkg/deployment/core.go
+++ b/parallel-install/pkg/deployment/core.go
@@ -3,7 +3,7 @@ package deployment
 
 import (
 	"context"
-	"fmt"
+	"github.com/pkg/errors"
 	"strings"
 	"time"
 

--- a/parallel-install/pkg/deployment/core.go
+++ b/parallel-install/pkg/deployment/core.go
@@ -70,7 +70,7 @@ func (i *core) getConfig() (overrides.Provider, *engine.Engine, *engine.Engine, 
 	overridesProvider, err := overrides.New(i.kubeClient, i.overrides.Map(), i.cfg.Log)
 
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Failed to create overrides provider: exiting")
+		return nil, nil, nil, fmt.Errorf("Failed to create overrides provider: exiting: %s ", err)
 	}
 
 	//create KymaComponentMetadataTemplate and set prerequisites flag
@@ -154,4 +154,6 @@ func registerOverridesInterceptors(kubeClient kubernetes.Interface, o *Overrides
 	//hide certificate data
 	o.AddInterceptor([]string{"global.domainName", "global.ingress.domainName"}, NewDomainNameOverrideInterceptor(kubeClient, log))
 	o.AddInterceptor([]string{"global.tlsCrt", "global.tlsKey"}, NewCertificateOverrideInterceptor("global.tlsCrt", "global.tlsKey"))
+	// make sure we don't install legacy CRDs
+	o.AddInterceptor([]string{"global.installCRDs"}, NewInstallLegacyCRDsInterceptor())
 }

--- a/parallel-install/pkg/deployment/core.go
+++ b/parallel-install/pkg/deployment/core.go
@@ -70,7 +70,7 @@ func (i *core) getConfig() (overrides.Provider, *engine.Engine, *engine.Engine, 
 	overridesProvider, err := overrides.New(i.kubeClient, i.overrides.Map(), i.cfg.Log)
 
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Failed to create overrides provider: exiting: %s ", err)
+		return nil, nil, nil, errors.Wrap(err, "Failed to create overrides provider: exiting")
 	}
 
 	//create KymaComponentMetadataTemplate and set prerequisites flag

--- a/parallel-install/pkg/deployment/overrideinterceptors.go
+++ b/parallel-install/pkg/deployment/overrideinterceptors.go
@@ -238,3 +238,25 @@ func NewFallbackOverrideInterceptor(fallback interface{}) *FallbackOverrideInter
 		fallback: fallback,
 	}
 }
+
+// This struct is introduced to ensure backward compatibility of Kyma 2.0 with 1.x
+// It can be removed when Kyma 2.0 is released
+type InstallLegacyCRDsInterceptor struct {}
+
+func (i *InstallLegacyCRDsInterceptor) String(value interface{}, key string) string {
+	return fmt.Sprintf("%v", value)
+}
+
+func (i *InstallLegacyCRDsInterceptor) Intercept(value interface{}, key string) (interface{}, error) {
+	// We should never install CRDs in the legacy way with Kyma 2.0
+	return false, nil
+}
+
+func (i*InstallLegacyCRDsInterceptor) Undefined(overrides map[string]interface{}, key string) error {
+	// We should never install CRDs in the legacy way with Kyma 2.0
+	return NewFallbackOverrideInterceptor(false).Undefined(overrides, key)
+}
+
+func NewInstallLegacyCRDsInterceptor() *InstallLegacyCRDsInterceptor {
+	return &InstallLegacyCRDsInterceptor{}
+}

--- a/parallel-install/pkg/deployment/overrideinterceptors.go
+++ b/parallel-install/pkg/deployment/overrideinterceptors.go
@@ -241,7 +241,7 @@ func NewFallbackOverrideInterceptor(fallback interface{}) *FallbackOverrideInter
 
 // This struct is introduced to ensure backward compatibility of Kyma 2.0 with 1.x
 // It can be removed when Kyma 2.0 is released
-type InstallLegacyCRDsInterceptor struct {}
+type InstallLegacyCRDsInterceptor struct{}
 
 func (i *InstallLegacyCRDsInterceptor) String(value interface{}, key string) string {
 	return fmt.Sprintf("%v", value)
@@ -252,7 +252,7 @@ func (i *InstallLegacyCRDsInterceptor) Intercept(value interface{}, key string) 
 	return false, nil
 }
 
-func (i*InstallLegacyCRDsInterceptor) Undefined(overrides map[string]interface{}, key string) error {
+func (i *InstallLegacyCRDsInterceptor) Undefined(overrides map[string]interface{}, key string) error {
 	// We should never install CRDs in the legacy way with Kyma 2.0
 	return NewFallbackOverrideInterceptor(false).Undefined(overrides, key)
 }

--- a/parallel-install/pkg/preinstaller/resourceparser.go
+++ b/parallel-install/pkg/preinstaller/resourceparser.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	"io/ioutil"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -87,7 +88,13 @@ func initializeDefaultDecoder() (runtime.Decoder, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	err = apiextv1.AddToScheme(sch)
+	if err != nil {
+		return nil, err
+	}
+
+	err = apiextv1beta1.AddToScheme(sch)
 	if err != nil {
 		return nil, err
 	}

--- a/parallel-install/pkg/preinstaller/resourceparser.go
+++ b/parallel-install/pkg/preinstaller/resourceparser.go
@@ -94,8 +94,7 @@ func initializeDefaultDecoder() (runtime.Decoder, error) {
 		return nil, err
 	}
 
-	err = apiextv1beta1.AddToScheme(sch)
-	if err != nil {
+	if err := apiextv1beta1.AddToScheme(sch); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

To ensure we don't install CRDs from cluster-essentials it's needed to add an interceptor, that will always set the `global.installCRDs` flag to false.

Changes proposed in this pull request:

- Add InstallLegacyCRDs interceptor

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Blocked by https://github.com/kyma-project/kyma/pull/10763, https://github.com/kyma-project/kyma/pull/11031