### PR TITLE
Rename master to main (leftover)

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,6 +1,6 @@
 <!--   Thank you for your contribution. Before you submit the pull request:
 1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
-2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
+2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
 3. Test your changes and attach their results to the pull request.
 4. Update the relevant documentation.
 -->


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Changed `master` to `main` in docs (leftover)

**Related issue(s)**
See issue https://github.com/kyma-project/community/issues/515