### PR TITLE
Fix k3d cluster name detection when using agents

### DIFF
--- a/parallel-install/pkg/deployment/overrideinterceptors_test.go
+++ b/parallel-install/pkg/deployment/overrideinterceptors_test.go
@@ -677,7 +677,8 @@ func fakeNode() *v1.Node {
 func fakeK3dNode() *v1.Node {
 	k3dNode := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "k3d-kyma-server-0",
+			Name:   "k3d-kyma-server-0",
+			Labels: map[string]string{"node-role.kubernetes.io/master": "true"},
 		},
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

K3d clusters with one or multiple agaents use master nodes with the name
pattern k3d-<cluster-name>-server-<id> and agent nodes with
k3d-<cluster-name>-agent-<id>. The latter case was not considered
previously.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also https://github.com/kyma-project/cli/issues/671