### PR TITLE
Expose recoverable attribute in InstallationError

### DIFF
--- a/install/installation/errors.go
+++ b/install/installation/errors.go
@@ -4,6 +4,7 @@ import "fmt"
 
 type InstallationError struct {
 	ShortMessage string
+	Recoverable  bool
 	ErrorEntries []ErrorEntry
 }
 

--- a/install/installation/installation.go
+++ b/install/installation/installation.go
@@ -623,6 +623,9 @@ func newInstallationError(installation v1alpha1.Installation) InstallationError 
 	installationError := InstallationError{
 		ShortMessage: fmt.Sprintf("installation error occurred: %s", installation.Status.Description),
 		ErrorEntries: make([]ErrorEntry, 0, len(installation.Status.ErrorLog)),
+		// Treat error as recoverable if the kyma-installer still retries to install/upgrade the component in error state,
+		// and hence the action: install label is still present on the installation resource.
+		Recoverable: installation.Labels[installationActionLabel] == "install",
 	}
 
 	for _, errLog := range installation.Status.ErrorLog {


### PR DESCRIPTION
**Description**

Expose recoverable attribute in `InstallationError`. The value is based on whether or not the `action: install` label is present on the installation resource. 
If it's there, the kyma-installer might resolve the error with it's next retry and so the error is still considered as recoverable. If the label is not there, the error is for sure not recoverable as kyma-installer stopped retrying and removed the label.
