### PR TITLE
Fix: Kyma sync function fails when the apirule AccessStrategie field is empty

### DIFF
--- a/function/pkg/workspace/workspace.go
+++ b/function/pkg/workspace/workspace.go
@@ -304,14 +304,15 @@ func toWorkspaceRules(rules []types.Rule) []Rule {
 func toWorkspaceAccessStrategies(accessStrategies []types.AccessStrategie) []AccessStrategie {
 	var out []AccessStrategie
 	for _, as := range accessStrategies {
-		out = append(out, AccessStrategie{
+		strategie := AccessStrategie{
 			Handler: as.Handler,
-			Config: AccessStrategieConfig{
-				JwksUrls:       as.Config.JwksUrls,
-				TrustedIssuers: as.Config.TrustedIssuers,
-				RequiredScope:  as.Config.RequiredScope,
-			},
-		})
+		}
+		if as.Config != nil {
+			strategie.Config.JwksUrls = as.Config.JwksUrls
+			strategie.Config.TrustedIssuers = as.Config.TrustedIssuers
+			strategie.Config.RequiredScope = as.Config.RequiredScope
+		}
+		out = append(out, strategie)
 	}
 
 	return out


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- as in the title

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/cli/issues/896