### PR TITLE
Change alpine-kubectl image to k8s-tools

### DIFF
--- a/install/installation/testdata/kyma-installer-upgrade.yaml
+++ b/install/installation/testdata/kyma-installer-upgrade.yaml
@@ -163,7 +163,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: certhelper
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
+        image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
         command:
           - bash
           - -c

--- a/install/installation/testdata/kyma-installer.yaml
+++ b/install/installation/testdata/kyma-installer.yaml
@@ -155,7 +155,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: certhelper
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
+          image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
           command:
             - bash
             - -c

--- a/install/installation/testdata/tiller-upgrade.yaml
+++ b/install/installation/testdata/tiller-upgrade.yaml
@@ -172,7 +172,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: certhelper
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
+          image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
           command:
             - bash
             - -c

--- a/install/installation/testdata/tiller.yaml
+++ b/install/installation/testdata/tiller.yaml
@@ -162,7 +162,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: certhelper
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
+          image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
           command:
             - bash
             - -c


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Image `eu.gcr.io/kyma-project/test-infra/alpine-kubectl` is deprecated and removed from the test-infra repo. This PR changes image `eu.gcr.io/kyma-project/test-infra/alpine-kubectl` to `eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/3647