### PR TITLE
Reverse prerequisites order when uninstalling

### DIFF
--- a/parallel-install/pkg/components/components.go
+++ b/parallel-install/pkg/components/components.go
@@ -11,7 +11,8 @@ import (
 
 //Provider is an entity that produces a list of components for Kyma installation or uninstallation.
 type Provider interface {
-	GetComponents() []KymaComponent
+	// GetComponents returns the component list in the provider either in natural or reverded order
+	GetComponents(reversed bool) []KymaComponent
 }
 
 //ComponentsProvider implements the Provider interface.
@@ -48,7 +49,7 @@ func NewComponentsProvider(overridesProvider overrides.Provider, cfg *config.Con
 }
 
 //Implements Provider.GetComponents.
-func (p *ComponentsProvider) GetComponents() []KymaComponent {
+func (p *ComponentsProvider) GetComponents(reversed bool) []KymaComponent {
 	helmClient := helm.NewClient(p.helmConfig)
 
 	var components []KymaComponent
@@ -62,7 +63,12 @@ func (p *ComponentsProvider) GetComponents() []KymaComponent {
 			HelmClient:      helmClient,
 			Log:             p.log,
 		}
-		components = append(components, cmp)
+		if reversed {
+			// prepend component to reverse the list
+			components = append([]KymaComponent{cmp}, components...)
+		} else {
+			components = append(components, cmp)
+		}
 	}
 
 	return components

--- a/parallel-install/pkg/components/components.go
+++ b/parallel-install/pkg/components/components.go
@@ -11,7 +11,7 @@ import (
 
 //Provider is an entity that produces a list of components for Kyma installation or uninstallation.
 type Provider interface {
-	// GetComponents returns the component list in the provider either in natural or reverded order
+	// GetComponents returns the component list in the provider either in natural or reversed order
 	GetComponents(reversed bool) []KymaComponent
 }
 

--- a/parallel-install/pkg/components/components_test.go
+++ b/parallel-install/pkg/components/components_test.go
@@ -56,6 +56,12 @@ func Test_GetComponents(t *testing.T) {
 	cmpMetadataTpl := helm.NewKymaComponentMetadataTemplate("version", "profile").ForComponents()
 	provider := NewComponentsProvider(overridesProvider, instCfg, instCfg.ComponentList.Components, cmpMetadataTpl)
 
-	res := provider.GetComponents()
+	res := provider.GetComponents(false)
 	require.Equal(t, 2, len(res), "Number of components not as expected")
+	require.Equal(t, "comp1", res[0].Name)
+
+	// test reversing
+	res = provider.GetComponents(true)
+	require.Equal(t, 2, len(res), "Number of components not as expected")
+	require.Equal(t, "comp2", res[0].Name)
 }

--- a/parallel-install/pkg/deployment/core_test.go
+++ b/parallel-install/pkg/deployment/core_test.go
@@ -34,7 +34,7 @@ type mockProvider struct {
 	hc *mockHelmClient
 }
 
-func (p *mockProvider) GetComponents(reverded bool) []components.KymaComponent {
+func (p *mockProvider) GetComponents(reversed bool) []components.KymaComponent {
 	return []components.KymaComponent{
 		{
 			Name:            "test1",

--- a/parallel-install/pkg/deployment/core_test.go
+++ b/parallel-install/pkg/deployment/core_test.go
@@ -34,7 +34,7 @@ type mockProvider struct {
 	hc *mockHelmClient
 }
 
-func (p *mockProvider) GetComponents() []components.KymaComponent {
+func (p *mockProvider) GetComponents(reverded bool) []components.KymaComponent {
 	return []components.KymaComponent{
 		{
 			Name:            "test1",

--- a/parallel-install/pkg/engine/engine.go
+++ b/parallel-install/pkg/engine/engine.go
@@ -75,7 +75,7 @@ type Installation interface {
 }
 
 func (e *Engine) Deploy(ctx context.Context) (<-chan components.KymaComponent, error) {
-	cmps := e.componentsProvider.GetComponents()
+	cmps := e.componentsProvider.GetComponents(false)
 
 	//TODO: Size dependent on number of components?
 	statusChan := make(chan components.KymaComponent, 30)
@@ -97,7 +97,7 @@ func (e *Engine) Deploy(ctx context.Context) (<-chan components.KymaComponent, e
 }
 
 func (e *Engine) Uninstall(ctx context.Context) (<-chan components.KymaComponent, error) {
-	cmps := e.componentsProvider.GetComponents()
+	cmps := e.componentsProvider.GetComponents(true)
 
 	//TODO: Size dependent on number of components?
 	statusChan := make(chan components.KymaComponent, 30)

--- a/parallel-install/pkg/engine/engine_test.go
+++ b/parallel-install/pkg/engine/engine_test.go
@@ -135,7 +135,7 @@ func TestSuccessScenario(t *testing.T) {
 
 	componentsProvider := &mockComponentsProvider{t, helmClient}
 
-	componentsToBeProcessed := componentsProvider.GetComponents()
+	componentsToBeProcessed := componentsProvider.GetComponents(false)
 
 	engineCfg := Config{
 		WorkersCount: defualtWorkersCount,
@@ -174,7 +174,7 @@ func TestErrorScenario(t *testing.T) {
 
 	componentsProvider := &mockComponentsProvider{t, helmClient}
 
-	componentsToBeProcessed := componentsProvider.GetComponents()
+	componentsToBeProcessed := componentsProvider.GetComponents(false)
 
 	engineCfg := Config{
 		WorkersCount: defualtWorkersCount,
@@ -286,7 +286,7 @@ type mockComponentsProvider struct {
 	hc helm.ClientInterface
 }
 
-func (p *mockComponentsProvider) GetComponents() []components.KymaComponent {
+func (p *mockComponentsProvider) GetComponents(reverdes bool) []components.KymaComponent {
 	var comps []components.KymaComponent
 	for _, name := range testComponentsNames {
 		component := components.KymaComponent{

--- a/parallel-install/pkg/engine/engine_test.go
+++ b/parallel-install/pkg/engine/engine_test.go
@@ -286,7 +286,7 @@ type mockComponentsProvider struct {
 	hc helm.ClientInterface
 }
 
-func (p *mockComponentsProvider) GetComponents(reverdes bool) []components.KymaComponent {
+func (p *mockComponentsProvider) GetComponents(reversed bool) []components.KymaComponent {
 	var comps []components.KymaComponent
 	for _, name := range testComponentsNames {
 		component := components.KymaComponent{


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Prerequisites are now uninstalled in the right order

**Related issue(s)**
#297 