### PR TITLE
Hide PreInstaller implementation structs, improve tests

### DIFF
--- a/parallel-install/pkg/deployment/deployment.go
+++ b/parallel-install/pkg/deployment/deployment.go
@@ -54,26 +54,26 @@ func (d *Deployment) StartKymaDeployment() error {
 		retry.DelayType(retry.FixedDelay),
 	}
 
-	preInstallerCfg := Config{
+	preInstallerCfg := inputConfig{
 		InstallationResourcePath: d.cfg.InstallationResourcePath,
 		Log:                      d.cfg.Log,
 		KubeconfigSource:         d.cfg.KubeconfigSource,
 		RetryOptions:             retryOpts,
 	}
 
-	preInstaller, err := NewPreInstaller(preInstallerCfg)
+	preInstaller, err := newPreInstaller(preInstallerCfg)
 	if err != nil {
 		d.cfg.Log.Fatalf("Failed to create Kyma pre-installer: %v", err)
 	}
 
-	result, err := preInstaller.InstallCRDs()
-	if err != nil || len(result.NotInstalled) > 0 {
-		d.cfg.Log.Fatalf("Failed to install CRDs: %s", err)
+	err = preInstaller.InstallCRDs()
+	if err != nil {
+		return err
 	}
 
-	result, err = preInstaller.CreateNamespaces()
-	if err != nil || len(result.NotInstalled) > 0 {
-		d.cfg.Log.Fatalf("Failed to create namespaces: %s", err)
+	err = preInstaller.CreateNamespaces()
+	if err != nil {
+		return err
 	}
 
 	overridesProvider, prerequisitesEng, componentsEng, err := d.getConfig()

--- a/parallel-install/pkg/deployment/preinstaller.go
+++ b/parallel-install/pkg/deployment/preinstaller.go
@@ -27,6 +27,7 @@ package deployment
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"io/ioutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"os"
@@ -37,8 +38,8 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-// Config defines configuration values for the preInstaller.
-type Config struct {
+// inputConfig defines configuration values for the preInstaller.
+type inputConfig struct {
 	InstallationResourcePath string                  //Path to the installation resources.
 	Log                      logger.Interface        //Logger to be used.
 	KubeconfigSource         config.KubeconfigSource //KubeconfigSource to be used.
@@ -49,23 +50,23 @@ type Config struct {
 type preInstaller struct {
 	applier       ResourceApplier
 	parser        ResourceParser
-	cfg           Config
+	cfg           inputConfig
 	dynamicClient dynamic.Interface
 }
 
-// File consists of a path to the file that was a part of preInstaller installation
+// file consists of a path to the file that was a part of preInstaller installation
 // and a component fileName that it belongs to.
-type File struct {
+type file struct {
 	component string
 	path      string
 }
 
-// Output contains lists of Installed and not Installed files during preInstaller installation.
-type Output struct {
+// output contains lists of Installed and not Installed files during preInstaller installation.
+type output struct {
 	// Installed files during preInstaller installation.
-	Installed []File
+	Installed []file
 	// NotInstalled files during preInstaller installation.
-	NotInstalled []File
+	NotInstalled []file
 }
 
 type resourceInfoInput struct {
@@ -83,8 +84,8 @@ type resourceInfoResult struct {
 	label        string
 }
 
-// NewPreInstaller creates a new instance of preInstaller.
-func NewPreInstaller(cfg Config) (*preInstaller, error) {
+// newPreInstaller creates a new instance of preInstaller.
+func newPreInstaller(cfg inputConfig) (*preInstaller, error) {
 	restConfig, err := config.RestConfig(cfg.KubeconfigSource)
 	if err != nil {
 		return nil, err
@@ -112,8 +113,8 @@ func NewPreInstaller(cfg Config) (*preInstaller, error) {
 }
 
 // InstallCRDs on a k8s cluster.
-// Returns Output containing results of installation.
-func (i *preInstaller) InstallCRDs() (Output, error) {
+// Returns output containing results of installation.
+func (i *preInstaller) InstallCRDs() error {
 	input := resourceInfoInput{
 		resourceType:             "CustomResourceDefinition",
 		dirSuffix:                "crds",
@@ -123,16 +124,16 @@ func (i *preInstaller) InstallCRDs() (Output, error) {
 
 	i.cfg.Log.Info("Kyma CRDs installation")
 	output, err := i.install(input)
-	if err != nil {
-		return Output{}, err
+	if err != nil || len(output.NotInstalled) > 0 {
+		return errors.Wrap(err, "Failed to install CRDs")
 	}
 
-	return output, nil
+	return nil
 }
 
 // CreateNamespaces in a k8s cluster.
-// Returns Output containing results of installation.
-func (i *preInstaller) CreateNamespaces() (Output, error) {
+// Returns output containing results of installation.
+func (i *preInstaller) CreateNamespaces() error {
 	input := resourceInfoInput{
 		resourceType:             "Namespace",
 		dirSuffix:                "namespaces",
@@ -142,17 +143,17 @@ func (i *preInstaller) CreateNamespaces() (Output, error) {
 
 	i.cfg.Log.Info("Kyma Namespaces creation")
 	output, err := i.install(input)
-	if err != nil {
-		return Output{}, err
+	if err != nil || len(output.NotInstalled) > 0 {
+		return errors.Wrap(err, "Failed to create namespaces")
 	}
 
-	return output, nil
+	return nil
 }
 
-func (i *preInstaller) install(input resourceInfoInput) (o Output, err error) {
+func (i *preInstaller) install(input resourceInfoInput) (o output, err error) {
 	resources, err := i.findResourcesIn(input)
 	if err != nil {
-		return Output{}, err
+		return output{}, err
 	}
 
 	return i.apply(resources)
@@ -204,9 +205,9 @@ func (i *preInstaller) findResourcesIn(input resourceInfoInput) (results []resou
 	return results, nil
 }
 
-func (i *preInstaller) apply(resources []resourceInfoResult) (o Output, err error) {
+func (i *preInstaller) apply(resources []resourceInfoResult) (o output, err error) {
 	for _, resource := range resources {
-		file := File{
+		file := file{
 			component: resource.component,
 			path:      resource.path,
 		}

--- a/parallel-install/pkg/deployment/preinstaller.go
+++ b/parallel-install/pkg/deployment/preinstaller.go
@@ -113,7 +113,6 @@ func newPreInstaller(cfg inputConfig) (*preInstaller, error) {
 }
 
 // InstallCRDs on a k8s cluster.
-// Returns output containing results of installation.
 func (i *preInstaller) InstallCRDs() error {
 	input := resourceInfoInput{
 		resourceType:             "CustomResourceDefinition",
@@ -132,7 +131,6 @@ func (i *preInstaller) InstallCRDs() error {
 }
 
 // CreateNamespaces in a k8s cluster.
-// Returns output containing results of installation.
 func (i *preInstaller) CreateNamespaces() error {
 	input := resourceInfoInput{
 		resourceType:             "Namespace",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- remove `output` struct from API (only used as a part of internal methods)
- unexport internal structs and constructor method
- improve tests by additional checks

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: https://github.com/kyma-project/hydroform/issues/265
