### PR TITLE
Add Verbose param to silence K8 deprecation warnings

### DIFF
--- a/parallel-install/pkg/config/config.go
+++ b/parallel-install/pkg/config/config.go
@@ -57,6 +57,8 @@ type Config struct {
 	Atomic bool
 	// Keep Kyma CRDs during deletion
 	KeepCRDs bool
+	// Silence deprecation warnings for K8s API
+	Verbose bool
 }
 
 // KubeconfigSource aggregates kubeconfig in a form of either a path or a raw content.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The deprecation warnings for the K8s API should be hidden from the enduser and only shown in the CLI with --verbose. 

Changes proposed in this pull request:

- silence stderr when applying CRD (except when verbose)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
