### PR TITLE
drop support for creating namespaces in preinstaller (#314)

### DIFF
--- a/parallel-install/pkg/deployment/deployment.go
+++ b/parallel-install/pkg/deployment/deployment.go
@@ -72,11 +72,6 @@ func (d *Deployment) StartKymaDeployment() error {
 		return err
 	}
 
-	err = preInstaller.CreateNamespaces()
-	if err != nil {
-		return err
-	}
-
 	overridesProvider, prerequisitesEng, componentsEng, err := d.getConfig()
 	if err != nil {
 		return err

--- a/parallel-install/pkg/deployment/preinstaller.go
+++ b/parallel-install/pkg/deployment/preinstaller.go
@@ -130,24 +130,6 @@ func (i *preInstaller) InstallCRDs() error {
 	return nil
 }
 
-// CreateNamespaces in a k8s cluster.
-func (i *preInstaller) CreateNamespaces() error {
-	input := resourceInfoInput{
-		resourceType:             "Namespace",
-		dirSuffix:                "namespaces",
-		installationResourcePath: i.cfg.InstallationResourcePath,
-		label:                    "",
-	}
-
-	i.cfg.Log.Info("Kyma Namespaces creation")
-	output, err := i.install(input)
-	if err != nil || len(output.NotInstalled) > 0 {
-		return errors.Wrap(err, "Failed to create namespaces")
-	}
-
-	return nil
-}
-
 func (i *preInstaller) install(input resourceInfoInput) (o output, err error) {
 	resources, err := i.findResourcesIn(input)
 	if err != nil {

--- a/parallel-install/pkg/test/data/resources/correct/namespaces/comp1/ns.yaml
+++ b/parallel-install/pkg/test/data/resources/correct/namespaces/comp1/ns.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: namespace

--- a/parallel-install/pkg/test/data/resources/correct/namespaces/comp2/ns.yaml
+++ b/parallel-install/pkg/test/data/resources/correct/namespaces/comp2/ns.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: namespace


### PR DESCRIPTION
the last usecase for this was cert-manager
that was removed in [0].

[0]: https://github.com/kyma-project/kyma/pull/11442

Resolves #314 