### PR TITLE
Remove verbose flag param

### DIFF
--- a/parallel-install/pkg/config/config.go
+++ b/parallel-install/pkg/config/config.go
@@ -57,8 +57,6 @@ type Config struct {
 	Atomic bool
 	// Keep Kyma CRDs during deletion
 	KeepCRDs bool
-	// Silence deprecation warnings for K8s API
-	Verbose bool
 }
 
 // KubeconfigSource aggregates kubeconfig in a form of either a path or a raw content.


### PR DESCRIPTION
Silencing of deprecation warning is handled by CLI now, so the related code can be removed.

**Description**

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
https://github.com/kyma-project/cli/pull/922