### PR TITLE
Remove kazydek from CODEOWNERS & add NHingerl

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,4 +16,4 @@
 /function @m00g3n @pPrecel @dbadura @tgorgol @rJankowski93
 
 # All .md files
-*.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova
+*.md @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl


### PR DESCRIPTION
**Description**

As Karolina is no longer an active contributor to the project, she must be removed from the CODEOWNERS. 
As Nina's been actively contributing to Kyma for some time now, she, in turn, must be added.

Changes proposed in this pull request:

- Remove @kazydek from CODEOWNERS
- Add @NHingerl to CODEOWNERS