### PR TITLE
Fix NPD in waitForShoot

### DIFF
--- a/provision/go.mod
+++ b/provision/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect

--- a/provision/go.sum
+++ b/provision/go.sum
@@ -259,6 +259,7 @@ github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=

--- a/provision/internal/operator/native/gardener/gardener_test.go
+++ b/provision/internal/operator/native/gardener/gardener_test.go
@@ -13,18 +13,17 @@ import (
 	k8sTesting "k8s.io/client-go/testing"
 )
 
-const (
-	testNamespace  = "someNamespace"
-	testShootsName = "someCluster"
-)
-
-type testCase struct {
-	name        string
-	shootObject func(name string, namespace string) *gardenerTypes.Shoot
-	assertErr   func(*testing.T, error)
-}
-
 func TestWaitForShoot(t *testing.T) {
+
+	const testNamespace = "someNamespace"
+	const testShootsName = "someCluster"
+
+	type testCase struct {
+		name        string
+		shootObject func(name string, namespace string) *gardenerTypes.Shoot
+		assertErr   func(*testing.T, error)
+	}
+
 	t.Parallel()
 	tests := []testCase{
 		{

--- a/provision/internal/operator/native/gardener/gardener_test.go
+++ b/provision/internal/operator/native/gardener/gardener_test.go
@@ -1,0 +1,101 @@
+package gardener
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gardenerTypes "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardenerFake "github.com/gardener/gardener/pkg/client/core/clientset/versioned/typed/core/v1beta1/fake"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sTesting "k8s.io/client-go/testing"
+)
+
+const (
+	testNamespace  = "someNamespace"
+	testShootsName = "someCluster"
+)
+
+type testCase struct {
+	name        string
+	shootObject func(name string, namespace string) *gardenerTypes.Shoot
+	assertErr   func(*testing.T, error)
+}
+
+func TestWaitForShoot(t *testing.T) {
+	t.Parallel()
+	tests := []testCase{
+		{
+			name:        "With proper LastOperation",
+			shootObject: stubForShootWithLastOperation(100, gardenerTypes.LastOperationStateSucceeded),
+			assertErr:   func(t *testing.T, err error) { require.NoError(t, err) },
+		},
+		{
+			name:        "Without LastOperation",
+			shootObject: stubForShootWithoutLastOperation(),
+			assertErr: func(t *testing.T, err error) {
+				require.Error(t, err)
+				require.Equal(t, "Provisioning timed out", err.Error())
+			},
+		},
+	}
+
+	for _, tst := range tests {
+		func(tcase testCase) {
+			t.Run(tcase.name, func(t *testing.T) {
+				t.Parallel()
+				//given
+				reactor := func(action k8sTesting.Action) (bool, runtime.Object, error) {
+					getAction := action.(k8sTesting.GetActionImpl)
+					testShoot := tcase.shootObject(getAction.Name, getAction.Namespace)
+					return true, testShoot, nil
+				}
+
+				f := &k8sTesting.Fake{}
+				f.AddReactor("get", "shoots", reactor)
+
+				ctx, _ := context.WithTimeout(context.Background(), 30*time.Millisecond)
+				fakeShootsGetter := gardenerFake.FakeCoreV1beta1{
+					Fake: f,
+				}
+
+				//when
+				err := waitForShoot(ctx, &fakeShootsGetter, testShootsName, testNamespace, 3*time.Millisecond)
+
+				//then
+				if tcase.assertErr != nil {
+					tcase.assertErr(t, err)
+				}
+			})
+		}(tst)
+	}
+}
+
+func stubForShootWithLastOperation(progress int32, state gardenerTypes.LastOperationState) func(name, namespace string) *gardenerTypes.Shoot {
+
+	return func(name, namespace string) *gardenerTypes.Shoot {
+		res := stubForShootWithoutLastOperation()(name, namespace)
+		res.Status.LastOperation = &gardenerTypes.LastOperation{
+			Progress: progress,
+			State:    state,
+		}
+		return res
+	}
+}
+
+func stubForShootWithoutLastOperation() func(name, namespace string) *gardenerTypes.Shoot {
+	return func(name, namespace string) *gardenerTypes.Shoot {
+		return &gardenerTypes.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Status: gardenerTypes.ShootStatus{
+				LastOperation: nil,
+			},
+		}
+	}
+
+}


### PR DESCRIPTION
**Description**

Resolves `nil pointer dereference` (NPD) in the `waitForShoot` function if the `Status.LastOperation` is nil

Changes proposed in this pull request:

- Add NPD protection
- Unit test that covers the bug scenario


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes: #395 
